### PR TITLE
Fixed GetRepo

### DIFF
--- a/python/dnfdaemon/server/__init__.py
+++ b/python/dnfdaemon/server/__init__.py
@@ -303,7 +303,7 @@ class DnfDaemonBase(dbus.service.Object, DownloadCallback):
         value = json.dumps(None)
         repo = self.base.repos.get(repo_id, None)  # get the repo object
         if repo:
-            repo_conf = dict([(c, getattr(repo, c)) for c in repo.iterkeys()])
+            repo_conf = dict([(c, getattr(repo, c)) for c in repo._option.keys()])
             value = json.dumps(repo_conf)
         return value
 


### PR DESCRIPTION
This patch fixes issue #11  and avoid the GetRepo(id) to crash providing a json as in dnf < 2.0